### PR TITLE
Error if GMT Offset = 0

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -198,8 +198,12 @@ class BasePlugin:
                     if(unit['id'] == response['DeviceID']):
                        date,time = response['NextCommunication'].split("T")
                        hours,minutes,sec = time.split(":")
-                       sign = Parameters["Mode1"][0]
-                       value = Parameters["Mode1"][1:]
+                       if Parameters["Mode1"] == '0':
+                            sign = '+'
+                            value = '0'
+                       else:
+                            sign = Parameters["Mode1"][0]
+                            value = Parameters["Mode1"][1:]
                        Domoticz.Debug("TIME OFFSSET :" + sign + value)
                        if(sign == "-"):
                             hours = int(hours) - int(value)


### PR DESCRIPTION
If GMT Offset = 0 : 'onMessage' failed 'ValueError':'invalid literal for int() with base 10: '''. on line 209