### PR TITLE
long term connection problem

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -25,7 +25,7 @@
 #        Usefull if you use your Mitsubishi remote
 # v0.1 : Initial release
 """
-<plugin key="MELCloud" version="0.7.8" name="MELCloud plugin" author="gysmo" wikilink="http://www.domoticz.com/wiki/Plugins/MELCloud.html" externallink="http://www.melcloud.com">
+<plugin key="MELCloud" version="0.7.9" name="MELCloud plugin" author="gysmo/kacper" wikilink="http://www.domoticz.com/wiki/Plugins/MELCloud.html" externallink="http://www.melcloud.com">
     <params>
         <param field="Username" label="Email" width="200px" required="true" />
         <param field="Password" label="Password" width="200px" required="true" password="true"/>
@@ -388,9 +388,16 @@ class BasePlugin:
         else:
             self.runAgain = self.runAgain - 1
             if self.runAgain <= 0:
+                try:
+                    if self.melcloud_conn is not None:
+                        self.melcloud_conn.Disconnect()
+                except:
+                    Domoticz.Debug("MELCloud connection disconnect failed.")
+                    
                 self.melcloud_conn = Domoticz.Connection(Name="MELCloud", Transport="TCP/IP", Protocol="HTTPS",
                                                          Address=self.melcloud_baseurl, Port=self.melcloud_port)
                 self.melcloud_key = None
+                self.list_units = []
                 self.melcloud_conn.Connect()
                 self.runAgain = 6
             else:

--- a/plugin.py
+++ b/plugin.py
@@ -28,7 +28,7 @@
 <plugin key="MELCloud" version="0.7.8" name="MELCloud plugin" author="gysmo" wikilink="http://www.domoticz.com/wiki/Plugins/MELCloud.html" externallink="http://www.melcloud.com">
     <params>
         <param field="Username" label="Email" width="200px" required="true" />
-        <param field="Password" label="Password" width="200px" required="true" />
+        <param field="Password" label="Password" width="200px" required="true" password="true"/>
         <param field="Mode1" label="GMT Offset" width="75 px">
             <options>
                 <option label="-12" value="-12"/>
@@ -388,9 +388,9 @@ class BasePlugin:
         else:
             self.runAgain = self.runAgain - 1
             if self.runAgain <= 0:
-                if self.melcloud_conn is None:
-                    self.melcloud_conn = Domoticz.Connection(Name="MELCloud", Transport="TCP/IP", Protocol="HTTPS",
-                                                             Address=self.melcloud_baseurl, Port=self.melcloud_port)
+                self.melcloud_conn = Domoticz.Connection(Name="MELCloud", Transport="TCP/IP", Protocol="HTTPS",
+                                                         Address=self.melcloud_baseurl, Port=self.melcloud_port)
+                self.melcloud_key = None
                 self.melcloud_conn.Connect()
                 self.runAgain = 6
             else:


### PR DESCRIPTION
MAC-577IF2-E
On regular basis (at every 3 days) I was losing connection with melcloud. The only way to regain access was to restart plugin. Looks like melcloud_key update is not performed properly.
I provide solution for this, maybe not in the most elegant way but at least working.